### PR TITLE
Resolvendo o problema de link do CSS e JS, além de adicionar a função de copiarTexto

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,13 +7,15 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Sono:wght@300&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="/style/style.css">
+    <link rel="stylesheet" href="style/style.css">
 
     <title>Encriptador de Texto | Alura</title>
 </head>
 <body>
     <header>
-        <img src="./img/logoAlura.png" alt="Logo da Alura">
+        <a href="index.html">
+            <img src="./img/logoAlura.png" alt="Logo da Alura">
+        </a>
     </header>
     
     <main>
@@ -32,11 +34,11 @@
         
         <section>
             <textarea class="mensagem"  cols="20" rows="10"></textarea>
-            <button class="btn-copiar">Copiar</button>
+            <button class="btn-copiar" onclick="copiarTexto()">Copiar</button>
         </section>
     </main>
 
-    <script src="/js/script.js"></script>
+    <script src="js/script.js"></script>
 
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -43,3 +43,9 @@ function desencriptar(stringDesencriptada) {
 
     return stringDesencriptada;
 }
+
+function copiarTexto() {
+    mensagem.select();
+    mensagem.setSelectionRange(0, 99999);
+    document.execCommand("copy");
+}


### PR DESCRIPTION
# Corrigindo o erro no CSS e JS

## CSS

- Por algum motivo, o estilo da página funcionava normalmente quando eu utilizava o `Live Server`, porém ficava sem estilo quando eu entrava pelo teu deploy no `GitHub Pages` ou quando eu acessava diretamente o arquivo index.html.
- Eu corrigi esse problema quando percebi que o teu link para o CSS dentro do HTML foi feito de forma errônea, colocando uma **"/"** na frente.
 
Estava assim:
```
<link rel="stylesheet" href="/style/style.css">
```
Tirei a barra no começo:
```
<link rel="stylesheet" href="style/style.css">
```

**Funcionou!!!**

- **Uma dica:** quando tu for direcionar para algum arquivo CSS ou JS, dentro do href (ou src) ainda vazio, dá `Ctrl + Espaço`. Dessa forma ele te dá opções de pastas e arquivos q tu pode selecionar.

## JS

- Adivinha só, o erro no JS aconteceu justamente pelo mesmo motivo do CSS. Tinha uma **"/"** na frente da pasta `js`. Por algum motivo, funciona no `Live Server`, mas não funciona acessando pelo arquivo index.html ou pelo `GitHub Pages`.
- Corrigi da mesma forma que fiz com o CSS, tirei a barra da frente.

Estava assim:
```
<script src="/js/script.js"></script>
```
Tirei a barra no começo:
```
<script src="js/script.js"></script>
```

**Funcionou novamente!!!**

# Adicionando coisas

- Envolvi a tag `img` do teu `header` dentro de uma âncora `a`, direcionando ao index.html. Dessa forma você pode clicar no logo da Alura e atualizar sua página.
- Adicionei uma função de `copiarTexto` para o seu botão de `Copiar`.